### PR TITLE
chore(package): update ember-cli-babel to version 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.6.0",
     "es5-shim": "~4.5.2",
     "pixi.js": "~3.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.0",
     "ember-cli-htmlbars": "^2.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "^0.14.0",
     "ember-cli-release": "^0.2.9",


### PR DESCRIPTION
Closes #28 
Closes #30 