### PR TITLE
Feature/fix warning when resizing renderer

### DIFF
--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -5,11 +5,18 @@ import PIXI from 'pixi';
 export default Component.extend({
   draw() {},
 
-  pixiRenderer: computed('width', 'height', function() {
+  pixiRenderer: computed(function() {
     let { width, height } = this.getProperties('width', 'height');
 
     return PIXI.autoDetectRenderer(width, height);
   }),
+
+  resizePixiRenderer: Ember.observer('width', 'height', function() {
+    let width = this.getAttr('width');
+    let height = this.getAttr('height');
+
+    this.get('pixiRenderer').resize(width, height);
+  },
 
   didReceiveAttrs() {
     let width = this.getAttr('width');

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -5,18 +5,18 @@ import PIXI from 'pixi';
 export default Component.extend({
   draw() {},
 
-  height: computed({
-    get() { },
+  height: computed('height', {
+    get() { return 600; },
     set(key, value) {
-      this.resizePixiRenderer();
+      this._resizePixiRenderer(this.get('width'), value);
       return value;
     }
   }),
 
-  width: computed({
-    get() { },
+  width: computed('width', {
+    get() { return 800; },
     set(key, value) {
-      this.resizePixiRenderer();
+      this._resizePixiRenderer(value, this.get('height'));
       return value;
     }
   }),
@@ -35,12 +35,6 @@ export default Component.extend({
     this.setProperties({ width, height });
   },
 
-  willUpdate() {
-    let currentCanvas = this.get('_currentCanvas');
-
-    this.$().children(currentCanvas).remove();
-  },
-
   didRender() {
     let renderer = this.get('pixiRenderer');
     let currentCanvas = renderer.view;
@@ -55,11 +49,7 @@ export default Component.extend({
     this.get('pixiRenderer').destroy();
   },
 
-  draw() {},
-
-  resizePixiRenderer() {
-    let width = this.get('width');
-    let height = this.get('height');
+  _resizePixiRenderer(width, height) {
     this.get('pixiRenderer').resize(width, height);
   }
 });

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -5,18 +5,28 @@ import PIXI from 'pixi';
 export default Component.extend({
   draw() {},
 
+  height: computed('height', {
+    get() { return 600; },
+    set(key, value) {
+      this.resizePixiRenderer(this.get('width'), value);
+      return value;
+    }
+  }),
+
+  width: computed('width', {
+    get() { return 800; },
+    set(key, value) {
+      this.resizePixiRenderer(value, this.get('height'));
+      return value;
+    }
+  }),
+
   pixiRenderer: computed(function() {
     let { width, height } = this.getProperties('width', 'height');
 
     return PIXI.autoDetectRenderer(width, height);
   }),
 
-  resizePixiRenderer: Ember.observer('width', 'height', function() {
-    let width = this.getAttr('width');
-    let height = this.getAttr('height');
-
-    this.get('pixiRenderer').resize(width, height);
-  },
 
   didReceiveAttrs() {
     let width = this.getAttr('width');
@@ -27,7 +37,7 @@ export default Component.extend({
 
   willDestroyElement() {
     this.get('pixiRenderer').destroy();
-  }
+  },
 
   willUpdate() {
     let currentCanvas = this.get('_currentCanvas');
@@ -43,5 +53,11 @@ export default Component.extend({
     this.$().append(currentCanvas);
 
     this.draw();
+  },
+
+  draw() {},
+
+  resizePixiRenderer(width, height) {
+    this.get('pixiRenderer').resize(width, height);
   }
 });

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -18,6 +18,16 @@ export default Component.extend({
     this.setProperties({ width, height });
   },
 
+  willDestroyElement() {
+    this.get('pixiRenderer').destroy();
+  }
+
+  willUpdate() {
+    let currentCanvas = this.get('_currentCanvas');
+
+    this.$().children(currentCanvas).remove();
+  },
+
   didRender() {
     let renderer = this.get('pixiRenderer');
     let currentCanvas = renderer.view;
@@ -26,11 +36,5 @@ export default Component.extend({
     this.$().append(currentCanvas);
 
     this.draw();
-  },
-
-  willUpdate() {
-    let currentCanvas = this.get('_currentCanvas');
-
-    this.$().children(currentCanvas).remove();
   }
 });

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -35,10 +35,6 @@ export default Component.extend({
     this.setProperties({ width, height });
   },
 
-  willDestroyElement() {
-    this.get('pixiRenderer').destroy();
-  },
-
   willUpdate() {
     let currentCanvas = this.get('_currentCanvas');
 
@@ -53,6 +49,10 @@ export default Component.extend({
     this.$().append(currentCanvas);
 
     this.draw();
+  },
+
+  willDestroyElement() {
+    this.get('pixiRenderer').destroy();
   },
 
   draw() {},

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -6,17 +6,17 @@ export default Component.extend({
   draw() {},
 
   height: computed({
-    get() { return 600; },
+    get() { },
     set(key, value) {
-      this.resizePixiRenderer(this.get('width'), value);
+      this.resizePixiRenderer();
       return value;
     }
   }),
 
   width: computed({
-    get() { return 800; },
+    get() { },
     set(key, value) {
-      this.resizePixiRenderer(value, this.get('height'));
+      this.resizePixiRenderer();
       return value;
     }
   }),
@@ -57,7 +57,9 @@ export default Component.extend({
 
   draw() {},
 
-  resizePixiRenderer(width, height) {
+  resizePixiRenderer() {
+    let width = this.get('width');
+    let height = this.get('height');
     this.get('pixiRenderer').resize(width, height);
   }
 });

--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -5,7 +5,7 @@ import PIXI from 'pixi';
 export default Component.extend({
   draw() {},
 
-  height: computed('height', {
+  height: computed({
     get() { return 600; },
     set(key, value) {
       this.resizePixiRenderer(this.get('width'), value);
@@ -13,7 +13,7 @@ export default Component.extend({
     }
   }),
 
-  width: computed('width', {
+  width: computed({
     get() { return 800; },
     set(key, value) {
       this.resizePixiRenderer(value, this.get('height'));

--- a/tests/integration/components/pixi-canvas-test.js
+++ b/tests/integration/components/pixi-canvas-test.js
@@ -31,7 +31,7 @@ describe('Integration: PixiCanvasComponent', function() {
     expect(height).to.eq(100);
   });
 
-  it('replaces the canvas element when the dimensions change', async function() {
+  it('resizes the canvas element when the dimensions change', async function() {
     this.set('width', 200);
     this.set('height', 100);
     await render(hbs`
@@ -40,14 +40,16 @@ describe('Integration: PixiCanvasComponent', function() {
 
     let oldCanvas = this.element.querySelector('canvas');
 
-    this.set('width', 100);
-    this.set('height', 50);
+    this.setProperties({
+      width: 100,
+      height: 50
+    });
 
     let newCanvas = this.element.querySelector('canvas');
     let width = Number(newCanvas.width);
     let height = Number(newCanvas.height);
 
-    expect(oldCanvas).to.not.eql(newCanvas);
+    expect(oldCanvas).to.eql(newCanvas);
     expect(width).to.eq(100);
     expect(height).to.eq(50);
   });


### PR DESCRIPTION
I am getting a the warning `Too many active WebGL contexts. Oldest context will be lost.` when resizing the canvas/renderer.

This fixes the problem for me.