### PR TITLE
replace jQuery call with standard DOM API

### DIFF
--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -37,11 +37,9 @@ export default Component.extend({
 
   didRender() {
     let renderer = this.get('pixiRenderer');
-    let currentCanvas = renderer.view;
+    let canvas = renderer.view;
 
-    this.set('_currentCanvas', currentCanvas);
-    this.$().append(currentCanvas);
-
+    this.element.appendChild(canvas);
     this.draw();
   },
 


### PR DESCRIPTION
There is no need for using jQuery to insert the canvas element into the DOM, we can just use standard DOM APIs instead.