### PR TITLE
remove width/height defaults

### DIFF
--- a/addon/components/pixi-canvas.js
+++ b/addon/components/pixi-canvas.js
@@ -6,7 +6,7 @@ export default Component.extend({
   draw() {},
 
   height: computed('height', {
-    get() { return 600; },
+    get() { },
     set(key, value) {
       this._resizePixiRenderer(this.get('width'), value);
       return value;
@@ -14,7 +14,7 @@ export default Component.extend({
   }),
 
   width: computed('width', {
-    get() { return 800; },
+    get() { },
     set(key, value) {
       this._resizePixiRenderer(value, this.get('height'));
       return value;


### PR DESCRIPTION
I accidentally merged #60 with some default numbers in the code for width and height. As those are arbitrary though, I don't think we should have them in the code and instead require these to be set explicitly.